### PR TITLE
Made queue types (including catenable versions) Traversable

### DIFF
--- a/Data/Sequence/FastQueue.hs
+++ b/Data/Sequence/FastQueue.hs
@@ -18,10 +18,18 @@
 -----------------------------------------------------------------------------
 
 module Data.Sequence.FastQueue(module Data.SequenceClass, FastQueue) where
+import Control.Applicative (pure, (<$>), (<*>))
+import Control.Applicative.Backwards
 import Data.SequenceClass
 import Data.Foldable
+import Data.Traversable
 import Prelude hiding (foldr,foldl)
 
+data Nat = Z | S Nat
+
+len :: [a] -> Nat
+len [] = Z
+len (_:xs) = S $ len xs
 
 revAppend l r = rotate l r []
 -- precondtion : |a| = |f| - (|r| - 1)
@@ -32,15 +40,15 @@ rotate (x : f) (y : r) a = x : rotate f r (y : a)
 rotate f        a     r  = error "Invariant |a| = |f| - (|r| - 1) broken"
 
 data FastQueue a where
-  RQ :: ![a] -> ![a] -> ![a] -> FastQueue a
+  RQ :: ![a] -> ![a] -> !Nat -> FastQueue a
 
-queue :: [a] -> [a] -> [a] -> FastQueue a
-queue f r [] = let f' = revAppend f r 
-                 in RQ f' [] f'
-queue f r (h : t) = RQ f r t
+queue :: [a] -> [a] -> Nat -> FastQueue a
+queue f r Z = let f' = revAppend f r
+                 in RQ f' [] $ len f'
+queue f r (S n) = RQ f r n
 
 instance Functor FastQueue where
-  fmap phi (RQ a b c) = RQ (fmap phi a) (fmap phi b) (fmap phi c)
+  fmap phi (RQ a b n) = RQ (fmap phi a) (fmap phi b) n
 
 instance Foldable FastQueue where
   foldl f = loop where
@@ -52,12 +60,18 @@ instance Foldable FastQueue where
            EmptyL -> []
            h :< t -> h : toRevList t
 
+instance Traversable FastQueue where
+  traverse f (RQ a b n) =
+    (\a b -> RQ a b n)
+      <$> traverse f a
+      <*> forwards (traverse (Backwards . f) b)
+
 instance Sequence FastQueue where
- empty = RQ [] [] []
- singleton x = let c = [x] in queue c [] c
+ empty = RQ [] [] Z
+ singleton x = queue [x] [] (S Z)
  (RQ f r a) |> x = queue f (x : r) a
 
- viewl (RQ [] [] []) = EmptyL
+ viewl (RQ [] [] Z) = EmptyL
  viewl (RQ (h : t) f a) = h :< queue t f a
 
 

--- a/sequence.cabal
+++ b/sequence.cabal
@@ -13,7 +13,7 @@ Data-files:          ChangeLog
 Category:            Data, Data Structures
 Tested-With:         GHC==7.6.3
 Library
-  Build-Depends: base >= 2 && <= 6, containers
+  Build-Depends: base >= 2 && <= 6, containers, transformers
   Exposed-modules: Data.SequenceClass, Data.Sequence.Queue, Data.Sequence.FastQueue, Data.Sequence.FastCatQueue,  Data.Sequence.ToCatQueue
   Extensions:	
 


### PR DESCRIPTION
It is possible for `LogicT` to become `Traversable` in more situations using the new implementation. But for that to happen, the queue types must also be `Traversable` (and `Foldable` in more cases than they were). I've made the required changes for that to happen.