### PR TITLE
Fix FastQueue

### DIFF
--- a/Data/Sequence/Any.hs
+++ b/Data/Sequence/Any.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
+-- We suppress this warning because otherwise GHC complains
+-- about the newtype constructor not being used.
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+#endif
+
+-- | It's safe to coerce /to/ 'Any' as long as you don't
+-- coerce back. We define our own 'Any' instead of using
+-- the one in "GHC.Exts" directly to ensure that this
+-- module doesn't clash with one making the opposite
+-- assumption. We use a newtype rather than a closed type
+-- family with no instances because the latter weren't supported
+-- until 8.0.
+module Control.Monad.Logic.Sequence.Internal.Any
+  ( Any
+  , toAnyList
+  ) where
+
+import Unsafe.Coerce
+import qualified GHC.Exts as E
+
+newtype Any = Any E.Any
+
+-- | Convert a list of anything to a list of 'Any'.
+toAnyList :: [a] -> [Any]
+toAnyList = unsafeCoerce

--- a/Data/Sequence/FastQueue.hs
+++ b/Data/Sequence/FastQueue.hs
@@ -1,72 +1,102 @@
-{-# LANGUAGE GADTs, ViewPatterns, TypeOperators #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE BangPatterns #-}
 
 
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Sequence.FastQueue
 -- Copyright   :  (c) Atze van der Ploeg 2014
+--                (c) David Feuer 2021
 -- License     :  BSD-style
 -- Maintainer  :  atzeus@gmail.org
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- A sequence, a queue, with worst case constant time: '|>', and 'tviewl'.
+-- A sequence, a queue, with worst case constant time: '|>', and 'viewl'.
 --
 -- Based on: "Simple and Efficient Purely Functional Queues and Deques", Chris Okasaki,
 -- Journal of Functional Programming 1995
 --
 -----------------------------------------------------------------------------
 
-module Data.Sequence.FastQueue(module Data.SequenceClass, FastQueue) where
-import Control.Applicative (pure, (<$>), (<*>))
-import Control.Applicative.Backwards
-import Data.SequenceClass
+module Data.Sequence.FastQueue 
+  ( module Data.SequenceClass
+  , FastQueue) where
+import Data.SequenceClass hiding ((:>))
 import Data.Foldable
-import Data.Traversable
-import Prelude hiding (foldr,foldl)
+import qualified Data.Traversable as T
+import Data.Sequence.Any
+import qualified Control.Applicative as A
 
-revAppend l r = rotate l r []
--- precondtion : |a| = |f| - (|r| - 1)
+#if !MIN_VERSION_base(4,8,0)
+import Data.Functor (Functor (..))
+import Data.Monoid (Monoid (..))
+#endif
+
+infixl 5 :>
+-- | A strict-spined snoc-list
+data SL a
+  = SNil
+  | !(SL a) :> a
+  deriving Functor
+
+-- | Append a snoc list to a list.
+appendSL :: [a] -> SL a -> [a]
+appendSL l r = rotate l r []
+-- precondition : |a| = |f| - (|r| - 1)
 -- postcondition: |a| = |f| - |r|
-rotate :: [a] -> [a]-> [a] -> [a]
-rotate []  [y] r = y : r
-rotate (x : f) (y : r) a = x : rotate f r (y : a)
-rotate f        a     r  = error "Invariant |a| = |f| - (|r| - 1) broken"
+rotate :: [a] -> SL a -> [a] -> [a]
+rotate [] (SNil :> y) r = y : r
+rotate (x : f) (r :> y) a = x : rotate f r (y : a)
+rotate _f _a _r  = error "Invariant |a| = |f| - (|r| - 1) broken"
 
-data FastQueue a where
-  RQ :: ![a] -> ![a] -> ![a] -> FastQueue a
+-- | A scheduled Banker's Queue, as described by Okasaki.
+data Queue a = RQ ![a] !(SL a) ![Any]
+  deriving Functor
+  -- We use 'Any' rather than an existential to allow GHC to unpack
+  -- queues if it's so inclined.
 
-queue :: [a] -> [a] -> [a] -> FastQueue a
-queue f r [] = let f' = revAppend f r 
-                 in RQ f' [] f'
-queue f r (h : t) = RQ f r t
+queue :: [a] -> SL a -> [Any] -> Queue a
+queue f r [] =
+  let
+    f' = appendSL f r
+    {-# NOINLINE f' #-}
+  in RQ f' SNil (toAnyList f')
+queue f r (_h : t) = RQ f r t
 
-instance Functor FastQueue where
-  fmap phi q = case viewl q of
-     EmptyL -> empty
-     h :< t -> phi h <| fmap phi t
+instance Sequence Queue where
+  empty = RQ [] SNil []
+  singleton x =
+    let
+      c = [x]
+      {-# NOINLINE c #-}
+    in RQ c SNil (toAnyList c)
+  RQ f r a |> x = queue f (r :> x) a
 
-instance Foldable FastQueue where
-  foldl f = loop where
-    loop i s = case viewl s of
-          EmptyL -> i
-          h :< t -> loop (f i h) t
-  foldr f i s = foldr f i (reverse $ toRevList s)
-    where toRevList s = case viewl s of
-           EmptyL -> []
-           h :< t -> h : toRevList t
+  viewl (RQ [] ~SNil ~[]) = EmptyL
+  viewl (RQ (h : t) f a) = h :< queue t f a
 
-instance Sequence FastQueue where
- empty = RQ [] [] []
- singleton x = let c = [x] in queue c [] c
- (RQ f r a) |> x = queue f (x : r) a
+instance Foldable Queue where
+  foldr c n = \q -> go q
+    where
+      go q = case viewl q of
+        EmptyL -> n
+        h :< t -> c h (go t)
+#if MIN_VERSION_base(4,6,0)
+  foldl' f b0 = \q -> go q b0
+    where
+      go q !b = case viewl q of
+        EmptyL -> b
+        h :< t -> go t (f b h)
+#endif
 
- viewl (RQ [] [] []) = EmptyL
- viewl (RQ (h : t) f a) = h :< queue t f a
+instance T.Traversable Queue where
+  traverse f = fmap fromList . go
+    where
+      go q = case viewl q of
+        EmptyL -> A.pure []
+        h :< t -> A.liftA2 (:) (f h) (go t)
 
-instance Traversable FastQueue where
-  sequenceA q = case viewl q of
-     EmptyL -> pure empty
-     h :< t  -> (<|) <$> h <*> sequenceA t
-   
-
+fromList :: [a] -> Queue a
+fromList = foldl' (|>) empty

--- a/sequence.cabal
+++ b/sequence.cabal
@@ -14,7 +14,14 @@ Category:            Data, Data Structures
 Tested-With:         GHC==7.6.3
 Library
   Build-Depends: base >= 2 && <= 6, containers, transformers
-  Exposed-modules: Data.SequenceClass,Data.Sequence.BSeq, Data.Sequence.Queue, Data.Sequence.FastQueue, Data.Sequence.FastCatQueue,  Data.Sequence.ToCatQueue
+  Exposed-modules:
+      Data.SequenceClass
+    , Data.Sequence.BSeq
+    , Data.Sequence.Queue
+    , Data.Sequence.FastQueue
+    , Data.Sequence.FastCatQueue
+    , Data.Sequence.ToCatQueue
+  Other-modules: Any
   Extensions:	
 
 source-repository head


### PR DESCRIPTION
* `FastQueue` would fail with invariant failure messages when faced
  with empty queues. Fix that. I don't know if it's exactly the right
  fix, but it seems to work. Note that this problem doesn't affect
  `FastCatQueue`, because that deals with empties separately.

* Make `foldr` properly lazy. This should be a win whether using it
  for simple things or for higher-order folds.

* Define `foldl'` explicitly, in case the default definition
  leaves any crud after optimization.

* Redefine `traverse` to avoid `(<|)`. The previous definition
  introduced `O(n^2)` work.

* Remove the explicit definition of `foldl`. There's no really good
  way to `foldl` one of these queues, so let's not try.

* Clean up unused extensions, imports, variables, etc.

* Use `NOINLINE` where we explicitly require sharing. I don't think
  the compiler would likely inline any of those places anyway, but
  I think it's best to be entirely clear.

* Use a sort of fake existential type for the schedule. This makes it
  clear that no values are taken from the schedule, while still allowing
  the compiler to unpack the `RQ` constructor.

* Use a custom (strict-spined) snoc list type. I think this makes it a
  little easier to see what's going on. I doubt the performance effect
  of the strict spine is noticeable, but in theory it should reduce code
  size a bit and maybe also reduce the load on the CPU branch
  prediction.

Fixes #2