### PR TITLE
Fix things back up

### DIFF
--- a/Data/Sequence/Any.hs
+++ b/Data/Sequence/Any.hs
@@ -15,8 +15,9 @@
 -- assumption. We use a newtype rather than a closed type
 -- family with no instances because the latter weren't supported
 -- until 8.0.
-module Control.Monad.Logic.Sequence.Internal.Any
+module Data.Sequence.Any
   ( Any
+  , toAny
   , toAnyList
   ) where
 
@@ -24,6 +25,10 @@ import Unsafe.Coerce
 import qualified GHC.Exts as E
 
 newtype Any = Any E.Any
+
+-- | Convert anything to 'Any'.
+toAny :: a -> Any
+toAny = unsafeCoerce
 
 -- | Convert a list of anything to a list of 'Any'.
 toAnyList :: [a] -> [Any]

--- a/sequence.cabal
+++ b/sequence.cabal
@@ -21,7 +21,7 @@ Library
     , Data.Sequence.FastQueue
     , Data.Sequence.FastCatQueue
     , Data.Sequence.ToCatQueue
-  Other-modules: Any
+  Other-modules: Data.Sequence.Any
   Extensions:	
 
 source-repository head


### PR DESCRIPTION
* The last commit got muddled. Fix that.
* Add a proper implementation of `<|` for `FastQueue` (this structure
  is inherently an output-restricted deque), and use it in `traverse`.