### PR TITLE
Upgrade Sequence superclass to Traversable

### DIFF
--- a/Data/SequenceClass.hs
+++ b/Data/SequenceClass.hs
@@ -44,7 +44,7 @@ Observation laws:
 
 The behaviour of '<|','|>', and 'viewr' is implied by the above laws and their default definitions.
 -}
-class (Functor s, Foldable s) => Sequence s where
+class Traversable s => Sequence s where
 
   empty     :: s c 
   singleton :: c  -> s c 


### PR DESCRIPTION
It was previously `(Functor, Foldable)`, which doesn't seem to
make a lot of sense.