### PR TITLE
Fix BSeq, etc.

### DIFF
--- a/Data/Sequence/BSeq.hs
+++ b/Data/Sequence/BSeq.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types,GADTs, DataKinds, TypeOperators #-}
+{-# LANGUAGE DeriveTraversable #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+#endif
 
 
 
@@ -12,46 +17,29 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- A sequence, implemented as a binary tree, good performance when used ephemerally
+-- A catenable qeueue, implemented as a binary tree,
+-- with good amortized performance when used ephemerally.
 --
 --
 -----------------------------------------------------------------------------
 module Data.Sequence.BSeq(module Data.SequenceClass,BSeq)  where
-import Control.Applicative (pure, (<*>), (<$>))
+import Control.Applicative hiding (empty)
 import Data.Foldable
-#if MIN_VERSION_base(4,9,0)
-import qualified Data.Semigroup as Semigroup
-#endif
 import Data.Monoid ((<>))
 import Data.Traversable
+import qualified Text.Read as TR
+#if MIN_VERSION_base(4,9,0)
+import qualified Data.Semigroup as Semigroup
+import Data.Functor.Classes (Show1 (..))
+#endif
+import Data.Function (on)
 import Prelude hiding (foldr,foldl)
 import Data.SequenceClass
 
+-- | A catenable queue intended for ephemeral use.
 data BSeq a = Empty | Leaf a | Node (BSeq a) (BSeq a)
-
-
-
-instance Functor BSeq where
-  fmap f = loop where
-    loop Empty = Empty
-    loop (Leaf x) = Leaf (f x)
-    loop (Node l r) = Node (loop l) (loop r)
-
-instance Foldable BSeq where
-  foldl f = loop where
-    loop i s = case viewl s of
-          EmptyL -> i
-          h :< t -> loop (f i h) t
-  foldr f i s = foldr f i (reverse $ toRevList s)
-    where toRevList s = case viewl s of
-           EmptyL -> []
-           h :< t -> h : toRevList t
-
-instance Traversable BSeq where
-  traverse f = loop where
-    loop Empty = pure Empty
-    loop (Leaf x) = Leaf <$> f x
-    loop (Node l r) = Node <$> loop l <*> loop r
+-- Invariant: Neither child of a Node may be Empty.
+  deriving (Functor, Foldable, Traversable)
 
 #if MIN_VERSION_base(4,9,0)
 instance Semigroup.Semigroup (BSeq a) where
@@ -65,13 +53,42 @@ instance Monoid (BSeq a) where
   mappend = (><)
 #endif
 
+instance Show a => Show (BSeq a) where
+    showsPrec p xs = showParen (p > 10) $
+        showString "fromList " . shows (toList xs)
+
+#if MIN_VERSION_base(4,9,0)
+instance Show1 BSeq where
+  liftShowsPrec _shwsPrc shwList p xs = showParen (p > 10) $
+        showString "fromList " . shwList (toList xs)
+#endif
+
+instance Read a => Read (BSeq a) where
+    readPrec = TR.parens $ TR.prec 10 $ do
+        TR.Ident "fromList" <- TR.lexP
+        xs <- TR.readPrec
+        return (fromList xs)
+
+    readListPrec = TR.readListPrecDefault
+
+instance Eq a => Eq (BSeq a) where
+  (==) = (==) `on` toList
+
+instance Ord a => Ord (BSeq a) where
+  compare = compare `on` toList
+
 instance Sequence BSeq where
   empty     = Empty
   singleton = Leaf
   Empty      >< r = r
   l          >< Empty = l
-  (Node l r) >< z = Node l (Node r z)
-  (Leaf x)   >< z = Node (Leaf x) z
-  viewl Empty               = EmptyL
-  viewl (Leaf x)            = x :< Empty
-  viewl (Node (Leaf x) r)   = x :< r
+  Node l r   >< z = Node l (Node r z)
+  l@(Leaf _) >< z = Node l z
+  viewl Empty         = EmptyL
+  viewl (Leaf x)      = x :< Empty
+  viewl (Node l r)    = case viewl l of
+    EmptyL -> error "Invariant failure"
+    x :< l' -> (x :<) $! l' >< r
+  fromList [] = Empty
+  fromList [x] = Leaf x
+  fromList (x : xs) = Node (Leaf x) (fromList xs)

--- a/Data/Sequence/FastCatQueue.hs
+++ b/Data/Sequence/FastCatQueue.hs
@@ -9,7 +9,7 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- A sequence, a catanable queue, with worst case constant time: '><', '|>', '<|' and 'tviewl'.
+-- A sequence, a catenable queue, with worst case constant time: '><', '|>', '<|' and 'viewl'.
 --
 -----------------------------------------------------------------------------
 module Data.Sequence.FastCatQueue(module Data.SequenceClass, FastTCQueue) where
@@ -18,4 +18,5 @@ import Data.SequenceClass
 import Data.Sequence.FastQueue
 import Data.Sequence.ToCatQueue
 
+-- | A catenable queue.
 type FastTCQueue =  ToCatQueue FastQueue


### PR DESCRIPTION
* Fix incomplete patterns error in `viewl` for `BSeq`.

* Make `BSeq` fold in the right order.

* Use derived `Functor`, `Foldable`, and `Traversable`
  instances everywhere we can.

* Add a `MINIMAL` pragma for `Sequence`.

* Continue to add basic instances.

* Expand `Sequence` documentation to explain that a `Sequence`
  is fundamentally a free monoid.

* Change `BSeq` documentation to indicate that its an (ephemeral)
  catenable queue, and not really a general sequence (access to
  the last element is not typically fast).

* Fill in missing documentation all over.