### PR TITLE
Make ToCatQueue properly persistent

### DIFF
--- a/Data/Sequence/BSeq/Internal.hs
+++ b/Data/Sequence/BSeq/Internal.hs
@@ -39,7 +39,23 @@ import Data.SequenceClass
 -- | A catenable queue intended for ephemeral use.
 data BSeq a = Empty | Leaf a | Node (BSeq a) (BSeq a)
 -- Invariant: Neither child of a Node may be Empty.
-  deriving (Functor, Foldable, Traversable)
+  deriving (Functor, Traversable)
+
+instance Foldable BSeq where
+  foldMap _ Empty = mempty
+  foldMap f (Leaf a) = f a
+  foldMap f (Node l r) = foldMap f l `mappend` foldMap f r
+
+  foldr _ n Empty = n
+  foldr c n (Leaf a) = c a n
+  foldr c n (Node l r) = foldr c (foldr c n r) l
+
+#if MIN_VERSION_base(4,8,0)
+  -- This implementation avoids digging into Nodes to see
+  -- that they're not empty.
+  null Empty = True
+  null _ = False
+#endif
 
 #if MIN_VERSION_base(4,9,0)
 instance Semigroup.Semigroup (BSeq a) where

--- a/Data/Sequence/FastQueue/Internal.hs
+++ b/Data/Sequence/FastQueue/Internal.hs
@@ -157,6 +157,11 @@ instance Foldable FastQueue where
         h :< t -> go t (f b h)
 #endif
 
+#if MIN_VERSION_base(4,8,0)
+  null (RQ [] _ _) = True
+  null _ = False
+#endif
+
 instance T.Traversable FastQueue where
   -- See note: folding and traversing
   traverse f = fmap fromList . go

--- a/Data/Sequence/Queue/Internal.hs
+++ b/Data/Sequence/Queue/Internal.hs
@@ -62,6 +62,8 @@ data Queue a  where
   QN :: !(B a) -> Queue (P a) -> !(B a) -> Queue a
 
 deriving instance Functor Queue
+-- The derived Foldable instance has an optimal null
+-- with a good unfolding. No need to fuss around with it.
 deriving instance Foldable Queue
 deriving instance Traversable Queue
 

--- a/Data/Sequence/ToCatQueue/Internal.hs
+++ b/Data/Sequence/ToCatQueue/Internal.hs
@@ -10,7 +10,6 @@
 #endif
 
 
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Sequence.ToCatQueue.Internal
@@ -88,14 +87,15 @@ instance Sequence q => Sequence (ToCatQueue q) where
  (CN x q)  >< ys  = CN x (q |> ys)
 
  viewl C0        = EmptyL
- viewl (CN h t)  = h :< linkAll t
-   where 
-    linkAll :: Sequence q =>  q (ToCatQueue q a)  -> ToCatQueue q a
-    linkAll v = case viewl v of
-     EmptyL     -> C0
-     CN x q :< t  -> CN x (q `snoc` linkAll t)
-    snoc q C0  = q
-    snoc q r   = q |> r
+ viewl (CN x q0)  = x :< case viewl q0 of
+   EmptyL -> C0
+   t :< q'  -> linkAll t q'
+   where
+   linkAll :: ToCatQueue q a -> q (ToCatQueue q a) -> ToCatQueue q a
+   linkAll t@(CN x q) q' = case viewl q' of
+     EmptyL -> t
+     h :< t' -> CN x (q |> linkAll h t')
+   linkAll C0 _ = error "Invariant failure"
 
  viewr = foldl' go EmptyR
    where


### PR DESCRIPTION
* The definition of `linkAll` was accidentally too strict, breaking
  the amortized bounds under persistent use. Fix that.

* Implement `null` manually for some queues to make sure it's optimal.