### PR TITLE
Move Any

### DIFF
--- a/Data/Sequence/FastQueue/Internal.hs
+++ b/Data/Sequence/FastQueue/Internal.hs
@@ -32,7 +32,7 @@ import Data.SequenceClass hiding ((:>))
 import qualified Data.SequenceClass as SC
 import Data.Foldable
 import qualified Data.Traversable as T
-import Data.Sequence.Any
+import Data.Sequence.FastQueue.Internal.Any
 import qualified Control.Applicative as A
 import Data.Function (on)
 import qualified Text.Read as TR

--- a/Data/Sequence/FastQueue/Internal/Any.hs
+++ b/Data/Sequence/FastQueue/Internal/Any.hs
@@ -5,8 +5,10 @@
 -- We suppress this warning because otherwise GHC complains
 -- about the newtype constructor not being used.
 #if __GLASGOW_HASKELL__ >= 800
+-- This warning doesn't seem to exist before 8.0, by any name.
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 #endif
+
 
 -- | It's safe to coerce /to/ 'Any' as long as you don't
 -- coerce back. We define our own 'Any' instead of using
@@ -15,7 +17,7 @@
 -- assumption. We use a newtype rather than a closed type
 -- family with no instances because the latter weren't supported
 -- until 8.0.
-module Data.Sequence.Any
+module Data.Sequence.FastQueue.Internal.Any
   ( Any
   , toAny
   , toAnyList

--- a/Data/Sequence/Queue/Internal.hs
+++ b/Data/Sequence/Queue/Internal.hs
@@ -96,7 +96,7 @@ instance Sequence Queue where
 
   (><) = foldl' (|>)
 
-  viewl q = case q of
+  viewl q0 = case q0 of
     Q0                    -> EmptyL
     Q1 a                  -> a :< Q0
     QN (B2 (a :* b)) m r  -> a :< QN (B1 b) m r
@@ -106,7 +106,7 @@ instance Sequence Queue where
                EmptyL -> buf2queue r
                l :< m -> QN (B2 l) m r
 
-  viewr q = case q of
+  viewr q0 = case q0 of
     Q0 -> EmptyR
     Q1 a -> Q0 :> a
     QN l m (B2 (a :* b)) -> QN l m (B1 a) :> b

--- a/Data/Sequence/ToCatQueue/Internal.hs
+++ b/Data/Sequence/ToCatQueue/Internal.hs
@@ -87,7 +87,7 @@ instance Sequence q => Sequence (ToCatQueue q) where
  (CN x q)  >< ys  = CN x (q |> ys)
 
  viewl C0        = EmptyL
- viewl (CN x q0)  = x :< case viewl q0 of
+ viewl (CN x0 q0)  = x0 :< case viewl q0 of
    EmptyL -> C0
    t :< q'  -> linkAll t q'
    where

--- a/sequence.cabal
+++ b/sequence.cabal
@@ -15,6 +15,7 @@ Category:            Data, Data Structures
 Tested-With:         GHC==7.6.3
 Library
   default-language: Haskell2010
+  ghc-options: -Wall -fno-warn-unused-imports
   build-depends: base >= 2 && <= 6, containers, transformers
   exposed-modules:
       Data.SequenceClass
@@ -27,11 +28,12 @@ Library
     , Data.Sequence.FastCatQueue
     , Data.Sequence.ToCatQueue
     , Data.Sequence.ToCatQueue.Internal
-    , Data.Sequence.Any
+    , Data.Sequence.FastQueue.Internal.Any
 
 test-suite sequence-test
   if impl(ghc < 7.10)
     buildable: False
+  ghc-options: -Wall -fno-warn-unused-imports
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   default-language: Haskell2010

--- a/test/BSeq.hs
+++ b/test/BSeq.hs
@@ -1,4 +1,5 @@
 {-# language BangPatterns #-}
+{-# options_ghc -fno-warn-orphans #-}
 module BSeq where
 import Data.Sequence.BSeq.Internal
 import Test.QuickCheck

--- a/test/FastQueue.hs
+++ b/test/FastQueue.hs
@@ -1,8 +1,10 @@
 {-# language BangPatterns #-}
+{-# options_ghc -fno-warn-orphans #-}
+
 module FastQueue where
 import Data.Sequence.FastQueue.Internal
 import Test.QuickCheck
-import Data.Sequence.Any
+import Data.Sequence.FastQueue.Internal.Any
 import Data.List (replicate)
 import Valid
 

--- a/test/Queue.hs
+++ b/test/Queue.hs
@@ -1,4 +1,6 @@
 {-# language BangPatterns #-}
+{-# options_ghc -fno-warn-orphans #-}
+
 module Queue where
 import Data.Sequence.Queue.Internal
 import Test.QuickCheck
@@ -53,6 +55,7 @@ mkArbQ n g
 mkArbB :: Int -> Gen a -> Gen (B a)
 mkArbB 1 g = B1 <$> g
 mkArbB 2 g = B2 <$> mkArbP g
+mkArbB _ _ = error "mkArbB must be called with 1 or 2."
 
 mkArbP :: Gen a -> Gen (P a)
 mkArbP g = (:*) <$> g <*> g

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -9,17 +9,18 @@ import Valid
 import Data.Proxy
 import Data.Foldable
 
-import FastQueue
+import FastQueue ()
 import Data.Sequence.FastQueue
-import BSeq
+import BSeq ()
 import Data.Sequence.BSeq
-import Queue
+import Queue ()
 import Data.Sequence.Queue
-import ToCatQueue
+import ToCatQueue ()
 import Data.Sequence.ToCatQueue
 
 type Usable s = (Arbitrary (s Int), Show (s Int), Eq (s Int), Valid s, Sequence s)
 
+main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
@@ -38,7 +39,7 @@ properties :: Usable s => Proxy s -> TestTree
 properties p = testGroup "Properties" [qcProps p]
 
 qcProps :: Usable s => Proxy s -> TestTree
-qcProps (p :: Proxy s) = testGroup "(checked by QuickCheck)" $
+qcProps (_ :: Proxy s) = testGroup "(checked by QuickCheck)" $
   [ QC.testProperty "generator valid" $
      -- We avoid trying to show an invalid generated sequence
      -- because doing so may raise an exception.

--- a/test/ToCatQueue.hs
+++ b/test/ToCatQueue.hs
@@ -1,10 +1,11 @@
 {-# language BangPatterns #-}
 {-# language LambdaCase #-}
+{-# options_ghc -fno-warn-orphans #-}
+
 module ToCatQueue where
 import Data.SequenceClass
 import Data.Sequence.ToCatQueue.Internal
 import Test.QuickCheck
-import Data.Sequence.Any
 import Data.List (replicate)
 import Data.Foldable (all)
 import Valid


### PR DESCRIPTION
* `Any` doesn't deserve such a prominent location. Tuck it away.
* Enable most warnings in the Cabal file and squash them. Unused
  imports are still an issue.