### PR TITLE
Prepare for release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+0.9.8.0:
+* Fixed incomplete pattern errors for `FastQueue` and `BSeq`.
+* Fixed fold order for `BSeq`.
+* Added a small test suite.
+* Added `Semigroup`, `Monoid`, `Eq`, `Ord`, `Show`, `Show1`,
+and `Read` instances for all the sequences.
+* Added a `fromList` method.
+* Made all method implementations reasonably efficient (to the
+extent possible for each structure). The defaults led to some
+operations being too slow to allow the test suite to complete.
+* Fixed a strictness bug in `viewl` for `FastQueue` that caused its
+amortized bounds to degrade under persistence.
+* Made folds and traversals for `FastQueue` respect the worst-case
+bounds for each element pulled.
+* Made `fmap` for `FastQueue` stop mapping over the schedule.
+* Arranged for GHC to be able to unpack `FastQueue`, though that
+will not immediately improve `FastCatQueue`.
 0.9.7: Added binary tree sequence datastructure
 0.9.6: Fixed bug in Functor for FastQueue which causes it be not O(1)
 0.9.5: Added traversable instances (thanks dolio!)

--- a/Data/Sequence/FastQueue/Internal.hs
+++ b/Data/Sequence/FastQueue/Internal.hs
@@ -47,10 +47,13 @@ import Data.Monoid (Monoid (..))
 #endif
 
 infixl 5 :>
--- | A strict-spined snoc-list
+-- | A lazy-spined snoc-list. Why lazy-spined? Only because
+-- that's better for `fmap`. In theory, strict-spined should
+-- be a bit better for everything else, but in practice it
+-- makes no measurable difference.
 data SL a
   = SNil
-  | !(SL a) :> a
+  | SL a :> a
   deriving Functor
 
 -- | Append a snoc list to a list.

--- a/sequence.cabal
+++ b/sequence.cabal
@@ -1,5 +1,5 @@
 Name:                sequence
-Version:             0.9.7
+Version:             0.9.8.0
 Synopsis:	     A type class for sequences and various sequence data structures.
 Description:         A type class for finite sequences along with several data structures
                      that implement it.


### PR DESCRIPTION
* Update changelog and Cabal file for release.
* Make the snoc-list for `FastQueue` lazy again. Making it strict
is bad for `fmap` and doesn't really affect anything else
significantly (as far as I can tell).